### PR TITLE
Parker dev

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "fsl-feat",
-  "label": "FSL: FEAT - fMRI preprocessing (v6.0)",
+  "label": "FSL: FEAT - fMRI preprocessing (v5.0)",
   "description": "FSL's FEAT (FMRI Expert Analysis Tool). As implemented in this Gear FEAT allows for basic preprocessing of an fMRI dataset including motion correction using MCFLIRT [Jenkinson 2002]; slice-timing correction using Fourier-space time-series phase-shifting; non-brain removal using BET [Smith 2002]; spatial smoothing using a Gaussian kernel; multiplicative mean intensity normalization of the volume at each timepoint; and highpass temporal filtering (Gaussian-weighted least-squares straight line fitting), brain extraction, and registration to a standard image (MNI152).",
   "maintainer": "Flywheel <support@flywheel.io>",
   "author": "Analysis Group, FMRIB, Oxford, UK.",
@@ -10,9 +10,9 @@
   "flywheel": {
     "suite": "FSL"
   },
-  "version": "0.1.4",
+  "version": "0.1.5",
   "custom": {
-    "docker-image": "flywheel/fsl-feat:0.1.4"
+    "docker-image": "flywheel/fsl-feat:0.1.5"
   },
   "config": {
     "BB_THRESH": {

--- a/manifest.json
+++ b/manifest.json
@@ -7,12 +7,17 @@
   "url": "http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FEAT",
   "source": "https://github.com/flywheel-apps/fsl-feat",
   "license": "Apache-2.0",
-  "flywheel": {
-    "suite": "FSL"
-  },
+
   "version": "0.1.5",
   "custom": {
-    "docker-image": "flywheel/fsl-feat:0.1.5"
+    "docker-image": "flywheel/fsl-feat:0.1.5",
+    "gear-builder": {
+      "category": "utility",
+      "image": "flywheel/fsl-feat:0.1.5"
+    },
+    "flywheel": {
+      "suite": "FSL"
+    }
   },
   "config": {
     "BB_THRESH": {

--- a/run
+++ b/run
@@ -67,7 +67,7 @@ fi
 
 ####################################################################
 # FillTemplate
-# Credit goes to David Parker @UPENN
+# Credit goes to David Parker @CUMC
 
 # VOLUME INFO
 ####################################################################


### PR DESCRIPTION
Gear info said it was running fsl 6.0, but docker image was 5.0.  Since I designed the template to work with 5.0, I just chose to modify the gear info rather than update the fsl version.