### PR TITLE
Add config options

### DIFF
--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -1,0 +1,20 @@
+## FSL Options
+1) Melodic ("inmelodic") => recommended by FSL for quick eval of motion artifacts, if nothing else
+   - Probably should automatically include the QA feat_output_directory.feat/filtered_func_data.ica/report/00index.html, even if we don't have a Melodic denoising gear
+   - Option for Melodic ICA data exploration is 0, make flexible?
+2) Analysis level will remain hard-coded for First-level for now
+3) Stages are fixed to Pre-processing (#1) only for now
+4) pre-stats processing => recommended default to be on, but should this be optional?
+5) Prewhitening is set to true and should remain this way, until/unless perfusion studies are being analyzed
+6) DOF: change the later to be optional 
+```
+   # Degrees of Freedom for registration to main structural  
+   set fmri(reghighres_dof) BBR  
+   # Degrees of Freedom for registration to standard space
+   set fmri(regstandard_dof) 12
+``` 
+7) Search space is currently set to default 90. Seems like this is sufficient, but may consider adding optional config (fetal scans/special FOV for hypothalamus)?
+8) FNIRT is currently disabled; not highly recommended, but should this be an option?
+```# Do nonlinear registration from structural to standard space?
+set fmri(regstandard_nonlinear_yn) 0
+```

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,3 +1,9 @@
+1.0.4_6.0
+### Documentation
+- Dev notes
+### Enhancements
+- Add configuration options for DOF, FNIRT, and Search Space
+
 1.0.3_6.0
 ### Documentation
 - Add docs + release_notes.md

--- a/manifest.json
+++ b/manifest.json
@@ -15,8 +15,9 @@
     },
     "DOF": {
       "default": 12,
-      "description": "Degrees of Freedom for registration to standard space",
-      "type": { "enum": [3, 6, 12]}
+      "description": "Degrees of Freedom for registration to standard space (allowed: 3, 6, 12)",
+      "type": "integer",
+      "enum": [3, 6, 12]
     },
     "FNIRT": {
       "default": 0,
@@ -78,7 +79,8 @@
     "SEARCH_SPACE": {
       "default": 90,
       "description": "Search space for registration to initial structural. 0 = no search; 90 = normal search; 180 = full search",
-      "type" : {"enum": [0, 90, 180]}
+      "type" : "integer",
+      "enum": [0, 90, 180]
     },
     "STC": {
       "default": 1,

--- a/manifest.json
+++ b/manifest.json
@@ -121,7 +121,7 @@
     },
     "gear-builder": {
       "category": "analysis",
-      "image": "flywheel/fsl-feat:1.0.3_6.0"
+      "image": "flywheel/fsl-feat:1.0.4_6.0"
     }
   },
   "description": "FSL's FEAT (FMRI Expert Analysis Tool). As implemented in this Gear FEAT allows for basic preprocessing of an fMRI dataset including motion correction using MCFLIRT [Jenkinson 2002]; slice-timing correction using Fourier-space time-series phase-shifting; non-brain removal using BET [Smith 2002]; spatial smoothing using a Gaussian kernel; multiplicative mean intensity normalization of the volume at each timepoint; and highpass temporal filtering (Gaussian-weighted least-squares straight line fitting), brain extraction, and registration to a standard image (MNI152).",
@@ -162,5 +162,5 @@
   "name": "fsl-feat",
   "source": "https://github.com/flywheel-apps/fsl-feat",
   "url": "http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FEAT",
-  "version": "1.0.3_6.0"
+  "version": "1.0.4_6.0"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -13,6 +13,18 @@
       "minimum": 0,
       "type": "integer"
     },
+    "DOF": {
+      "default": 12,
+      "description": "Degrees of Freedom for registration to standard space",
+      "type": { "enum": [3, 6, 12]}
+    },
+    "FNIRT": {
+      "default": 0,
+      "description": "Do nonlinear registration from structural to standard space? (default no = 0)",
+      "maximum": 1,
+      "minimum": 0,
+      "type": "integer"
+    },
     "FWHM": {
       "default": 5,
       "description": "FWHM FOR SPATIAL SMOOTHING (mm) [default=5]",
@@ -62,6 +74,11 @@
       "maximum": 1,
       "minimum": 0,
       "type": "integer"
+    },
+    "SEARCH_SPACE": {
+      "default": 90,
+      "description": "Search space for registration to initial structural. 0 = no search; 90 = normal search; 180 = full search",
+      "type" : {"enum": [0, 90, 180]}
     },
     "STC": {
       "default": 1,

--- a/manifest.json
+++ b/manifest.json
@@ -1,117 +1,117 @@
 {
-  "name": "fsl-feat",
-  "label": "FSL: FEAT - fMRI preprocessing (v6.0)",
-  "description": "FSL's FEAT (FMRI Expert Analysis Tool). As implemented in this Gear FEAT allows for basic preprocessing of an fMRI dataset including motion correction using MCFLIRT [Jenkinson 2002]; slice-timing correction using Fourier-space time-series phase-shifting; non-brain removal using BET [Smith 2002]; spatial smoothing using a Gaussian kernel; multiplicative mean intensity normalization of the volume at each timepoint; and highpass temporal filtering (Gaussian-weighted least-squares straight line fitting), brain extraction, and registration to a standard image (MNI152).",
-  "maintainer": "Flywheel <support@flywheel.io>",
   "author": "Analysis Group, FMRIB, Oxford, UK.",
-  "url": "http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FEAT",
-  "source": "https://github.com/flywheel-apps/fsl-feat",
-  "license": "Apache-2.0",
-  "version": "1.0.3_6.0",
-  "custom": {
-    "gear-builder": {
-      "category": "analysis",
-      "image": "flywheel/fsl-feat:1.0.3_6.0"
-    },
-
-  "flywheel": {
-      "suite": "Image Processing - Functional",
-      "type": ["NIFTI"],
-      "modality": ["MR"],
-      "classification": ["fMRI"],
-      "components": ["FSL"]
-    }
-  },
   "config": {
     "BB_THRESH": {
-      "description": "SET THE BRAIN BACKGROUND THRESHOLD. This is used in intensity normalisation, brain mask generation and various other places in the analysis. [Default=10]",
       "default": 10,
+      "description": "SET THE BRAIN BACKGROUND THRESHOLD. This is used in intensity normalisation, brain mask generation and various other places in the analysis. [Default=10]",
       "type": "number"
-    },
-    "Z_THRESH": {
-      "description": "SET THE Z THRESHOLD FOR DESIGN EFFICIENCY CALCULATION. Used to determine what level of activation would be statistically significant, to be used only in the design efficiency calculation. Increasing this will result in higher estimates of required effect. [default=5.3]",
-      "default": 5.3,
-      "type": "number"
-    },
-    "NOISE_LVL": {
-      "description": "SET THE FMRI NOISE LEVEL. The standard deviation (over time) for a typical voxel, expressed as a percentage of the baseline signal level. [default=0.66]",
-      "default": 0.66,
-      "type": "number"
-    },
-    "T_SMOOTH": {
-      "description": "SET TNE TEMPORAL SMOOTHNESS is the smoothness coefficient in a simple AR(1) autocorrelation model (much simpler than that actually used in the FILM timeseries analysis but good enough for the efficiency calculation here). [default=0.34]",
-      "default": 0.34,
-      "type": "number"
-    },
-    "MC": {
-      "description": "RUN MOTION CORRECTION [1=yes, 0=no. default=1]",
-      "default": 1,
-      "minimum": 0,
-      "maximum": 1,
-      "type": "integer"
-    },
-    "STC": {
-      "description": "RUN SLICE TIMING CORRECTION 0 = None. 1 = Regular up (0, 1, 2, 3, ...). 2 = Regular down. 3 = Use slice order file. 4 = Use slice timings file. 5 = Interleaved (0, 2, 4 ... 1, 3, 5 ... )",
-      "default": 1,
-      "type": "integer"
     },
     "BET": {
-      "description": "RUN BRAIN EXTRACTION USING FSL's BET [1=yes, 0=no. default=1]",
       "default": 1,
-      "minimum": 0,
+      "description": "RUN BRAIN EXTRACTION USING FSL's BET [1=yes, 0=no. default=1]",
       "maximum": 1,
+      "minimum": 0,
       "type": "integer"
     },
     "FWHM": {
-      "description": "FWHM FOR SPATIAL SMOOTHING (mm) [default=5]",
       "default": 5,
-      "type": "number"
-    },
-    "INT_NORM": {
-      "description": "RUN INTENSITY NORMALIZATION [1=yes, 0=no. default=1]",
-      "default": 1,
-      "minimum": 0,
-      "maximum": 1,
-      "type": "integer"
-    },
-    "HPF_CUTOFF": {
-      "description": "HIGHPASS FILTER CUTOFF (seconds) [default=100]",
-      "default": 100,
+      "description": "FWHM FOR SPATIAL SMOOTHING (mm) [default=5]",
       "type": "number"
     },
     "HPF": {
-      "description": "RUN HIGHPASS FILTERING [1=yes, 0=no. default=1]",
       "default": 1,
-      "minimum": 0,
+      "description": "RUN HIGHPASS FILTERING [1=yes, 0=no. default=1]",
       "maximum": 1,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "HPF_CUTOFF": {
+      "default": 100,
+      "description": "HIGHPASS FILTER CUTOFF (seconds) [default=100]",
+      "type": "number"
+    },
+    "INT_NORM": {
+      "default": 1,
+      "description": "RUN INTENSITY NORMALIZATION [1=yes, 0=no. default=1]",
+      "maximum": 1,
+      "minimum": 0,
       "type": "integer"
     },
     "LPF": {
-      "description": "RUN LOWPASS FILTERING [1=yes, 0=no. default=0]",
       "default": 0,
-      "minimum": 0,
+      "description": "RUN LOWPASS FILTERING [1=yes, 0=no. default=0]",
       "maximum": 1,
+      "minimum": 0,
       "type": "integer"
+    },
+    "MC": {
+      "default": 1,
+      "description": "RUN MOTION CORRECTION [1=yes, 0=no. default=1]",
+      "maximum": 1,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "NOISE_LVL": {
+      "default": 0.66,
+      "description": "SET THE FMRI NOISE LEVEL. The standard deviation (over time) for a typical voxel, expressed as a percentage of the baseline signal level. [default=0.66]",
+      "type": "number"
     },
     "REG_STANDARD_IMAGE": {
-      "description": "REGISTER TO A STANDARD IMAGE [1=yes, 0=no. default=1]. If Standard Template not supplied as an input, MNI152 2mm will be used.",
       "default": 1,
-      "minimum": 0,
+      "description": "REGISTER TO A STANDARD IMAGE [1=yes, 0=no. default=1]. If Standard Template not supplied as an input, MNI152 2mm will be used.",
       "maximum": 1,
+      "minimum": 0,
       "type": "integer"
     },
-    "Use_alt_template": {
-      "description": "Use the specified template (from the inputs tab) to register the images. [1=yes, 0=no. default=0]",
-      "default": 0,
-      "minimum": 0,
-      "maximum": 1,
+    "STC": {
+      "default": 1,
+      "description": "RUN SLICE TIMING CORRECTION 0 = None. 1 = Regular up (0, 1, 2, 3, ...). 2 = Regular down. 3 = Use slice order file. 4 = Use slice timings file. 5 = Interleaved (0, 2, 4 ... 1, 3, 5 ... )",
       "type": "integer"
+    },
+    "T_SMOOTH": {
+      "default": 0.34,
+      "description": "SET TNE TEMPORAL SMOOTHNESS is the smoothness coefficient in a simple AR(1) autocorrelation model (much simpler than that actually used in the FILM timeseries analysis but good enough for the efficiency calculation here). [default=0.34]",
+      "type": "number"
+    },
+    "Use_alt_template": {
+      "default": 0,
+      "description": "Use the specified template (from the inputs tab) to register the images. [1=yes, 0=no. default=0]",
+      "maximum": 1,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "Z_THRESH": {
+      "default": 5.3,
+      "description": "SET THE Z THRESHOLD FOR DESIGN EFFICIENCY CALCULATION. Used to determine what level of activation would be statistically significant, to be used only in the design efficiency calculation. Increasing this will result in higher estimates of required effect. [default=5.3]",
+      "type": "number"
     }
   },
+  "custom": {
+    "flywheel": {
+      "classification": [
+        "fMRI"
+      ],
+      "components": [
+        "FSL"
+      ],
+      "modality": [
+        "MR"
+      ],
+      "suite": "Image Processing - Functional",
+      "type": [
+        "NIFTI"
+      ]
+    },
+    "gear-builder": {
+      "category": "analysis",
+      "image": "flywheel/fsl-feat:1.0.3_6.0"
+    }
+  },
+  "description": "FSL's FEAT (FMRI Expert Analysis Tool). As implemented in this Gear FEAT allows for basic preprocessing of an fMRI dataset including motion correction using MCFLIRT [Jenkinson 2002]; slice-timing correction using Fourier-space time-series phase-shifting; non-brain removal using BET [Smith 2002]; spatial smoothing using a Gaussian kernel; multiplicative mean intensity normalization of the volume at each timepoint; and highpass temporal filtering (Gaussian-weighted least-squares straight line fitting), brain extraction, and registration to a standard image (MNI152).",
   "inputs": {
     "NIFTI": {
-      "description": "FUNCTIONAL NIfTI file to be processed.",
       "base": "file",
+      "description": "FUNCTIONAL NIfTI file to be processed.",
       "type": {
         "enum": [
           "nifti"
@@ -119,8 +119,8 @@
       }
     },
     "SLICE_FILE": {
-      "description": "SLICE ORDER/TIMING FILE. Must set STC config option to 3.",
       "base": "file",
+      "description": "SLICE ORDER/TIMING FILE. Must set STC config option to 3.",
       "optional": true,
       "type": {
         "enum": [
@@ -129,8 +129,8 @@
       }
     },
     "STANDARD_TEMPLATE": {
-      "description": "Template to which other images are registered. Must set REG_STANDARD_IMAGE to 1.",
       "base": "file",
+      "description": "Template to which other images are registered. Must set REG_STANDARD_IMAGE to 1.",
       "optional": true,
       "type": {
         "enum": [
@@ -138,5 +138,12 @@
         ]
       }
     }
-  }
+  },
+  "label": "FSL: FEAT - fMRI preprocessing (v6.0)",
+  "license": "Apache-2.0",
+  "maintainer": "Flywheel <support@flywheel.io>",
+  "name": "fsl-feat",
+  "source": "https://github.com/flywheel-apps/fsl-feat",
+  "url": "http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FEAT",
+  "version": "1.0.3_6.0"
 }

--- a/run
+++ b/run
@@ -63,6 +63,9 @@ FW_CONFIG_HPF="$(parse_config 'HPF')"
 FW_CONFIG_REG_STANDARD_IMAGE="$(parse_config 'REG_STANDARD_IMAGE')"
 FW_CONFIG_LPF="$(parse_config 'LPF')"
 FW_CONFIG_ALT_TEMPLATE="$(parse_config 'Use_alt_template')"
+FW_DOF="$(parse_config 'DOF')"
+FW_FNIRT="$(parse_config 'FNIRT')"
+FW_SEARCH_SPACE="$(parse_config 'SEARCH_SPACE')"
 
 ###############################################################################
 # INPUT File
@@ -190,6 +193,16 @@ HPF=$FW_CONFIG_HPF
 # RUN LOWPASS FILTERING
 LPF=$FW_CONFIG_LPF
 
+# Select Degrees of Freedom for registration
+DOF=$FW_DOF
+
+# Use nonlinear registration
+FNIRT=$FW_FNIRT
+
+# How exhaustive is the search space?
+SEARCH_SPACE=$FW_SEARCH_SPACE
+
+
 REG_STANDARD_IMAGE=$FW_CONFIG_REG_STANDARD_IMAGE
 
 ####################################################################
@@ -198,7 +211,7 @@ REG_STANDARD_IMAGE=$FW_CONFIG_REG_STANDARD_IMAGE
 
 # Create a lost of all the variable names
 # which match the place-holding text in the template
-VAR_STRINGS=( INPUT_DATA TR NUM_VOL NUM_VOX DEL_VOL FEAT_OUTPUT_DIR BB_THRESH Z_THRESH NOISE_LVL T_SMOOTH MC STC SLICE_FILE BET FWHM INT_NORM HPF_CUTOFF HPF LPF REG_STANDARD_IMAGE STANDARD_TEMPLATE)
+VAR_STRINGS=( INPUT_DATA TR NUM_VOL NUM_VOX DEL_VOL FEAT_OUTPUT_DIR BB_THRESH Z_THRESH NOISE_LVL T_SMOOTH MC STC SLICE_FILE BET FWHM INT_NORM HPF_CUTOFF HPF LPF DOF FNIRT SEARCH_SPACE REG_STANDARD_IMAGE STANDARD_TEMPLATE)
 
 DESIGN_FILE=${OUTPUT_DIR}/design.fsf
 cp ${TEMPLATE} ${DESIGN_FILE}

--- a/template.fsf
+++ b/template.fsf
@@ -215,7 +215,7 @@ set fmri(reginitial_highres_yn) 0
 # 0   : No search
 # 90  : Normal search
 # 180 : Full search
-set fmri(reginitial_highres_search) 90
+set fmri(reginitial_highres_search) ^SEARCH_SPACE^
 
 # Degrees of Freedom for registration to initial structural
 set fmri(reginitial_highres_dof) 3
@@ -248,10 +248,10 @@ set fmri(regstandard) "^STANDARD_TEMPLATE^"
 set fmri(regstandard_search) 90
 
 # Degrees of Freedom for registration to standard space
-set fmri(regstandard_dof) 12
+set fmri(regstandard_dof) ^DOF^
 
 # Do nonlinear registration from structural to standard space?
-set fmri(regstandard_nonlinear_yn) 0
+set fmri(regstandard_nonlinear_yn) ^FNIRT^
 
 # Control nonlinear warp field resolution
 set fmri(regstandard_nonlinear_warpres) 10


### PR DESCRIPTION
Add three config options: DOF, FNIRT, and SEARCH SPACE

Tests pass on GA and Rollout, with the caveat that something is not set in the web-UI to limit the entries for integer enums. (Front end is on it)

Closes GEAR-1492